### PR TITLE
DSND-2049: Fix deserialisation error with unrecognised field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <jib.version>3.3.1</jib.version>
     <structured-logging.version>1.9.25</structured-logging.version>
     <api-sdk-manager-java-library.version>1.0.6</api-sdk-manager-java-library.version>
-    <private-api-sdk-java.version>2.0.255</private-api-sdk-java.version>
+    <private-api-sdk-java.version>2.0.294</private-api-sdk-java.version>
     <kafka-models.version>1.0.31</kafka-models.version>
     <skip.unit.tests>false</skip.unit.tests>
     <skip.integration.tests>false</skip.integration.tests>

--- a/src/test/java/uk/gov/companieshouse/appointments/subdelta/companyprofile/CompanyProfileChangedServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/appointments/subdelta/companyprofile/CompanyProfileChangedServiceTest.java
@@ -1,17 +1,23 @@
 package uk.gov.companieshouse.appointments.subdelta.companyprofile;
 
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,6 +25,7 @@ import org.junit.jupiter.api.function.Executable;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.ClassPathResource;
 import uk.gov.companieshouse.api.company.Data;
 import uk.gov.companieshouse.appointments.subdelta.exception.NonRetryableException;
 import uk.gov.companieshouse.stream.ResourceChangedData;
@@ -47,12 +54,14 @@ class CompanyProfileChangedServiceTest {
         ResourceChangedData changedData = new ResourceChangedData();
         changedData.setResourceUri(CHANGED_COMPANY_PROFILE_RESOURCE_URI);
         changedData.setContextId(CONTEXT_ID);
-        String companyProfileData = "{ \"company_name\": \"COMPANY LIMITED\", \"company_status\": \"active\" }";
+
+        InputStream resource = new ClassPathResource("/example_stream_company_profile_message.json").getInputStream();
+        String companyProfileData = new String(resource.readAllBytes());
         changedData.setData(companyProfileData);
 
         Data data = new Data()
-                .companyName("COMPANY LIMITED")
-                .companyStatus("active");
+                .companyName(COMPANY_NAME)
+                .companyStatus(COMPANY_STATUS);
         when(objectMapper.readValue(anyString(), eq(Data.class))).thenReturn(data);
 
         // when
@@ -82,5 +91,4 @@ class CompanyProfileChangedServiceTest {
         assertEquals(DESERIALISE_FAILED_MESSAGE, exception.getMessage());
         verifyNoInteractions(appointmentsClient);
     }
-
 }

--- a/src/test/java/uk/gov/companieshouse/appointments/subdelta/companyprofile/CompanyProfileChangedServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/appointments/subdelta/companyprofile/CompanyProfileChangedServiceTest.java
@@ -11,10 +11,8 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.io.IOException;
 import java.io.InputStream;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/uk/gov/companieshouse/appointments/subdelta/companyprofile/CompanyProfileChangedServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/appointments/subdelta/companyprofile/CompanyProfileChangedServiceTest.java
@@ -1,23 +1,20 @@
 package uk.gov.companieshouse.appointments.subdelta.companyprofile;
 
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/resources/example_stream_company_profile_message.json
+++ b/src/test/resources/example_stream_company_profile_message.json
@@ -1,0 +1,67 @@
+{
+  "accounts": {
+    "accounting_reference_date": {
+      "day": "31",
+      "month": "12"
+    },
+    "last_accounts": {
+      "made_up_to": "2014-12-31",
+      "period_end_on": "2014-12-31",
+      "period_start_on": "2014-01-01",
+      "type": "medium"
+    },
+    "next_accounts": {
+      "due_on": "2016-06-30",
+      "overdue": true,
+      "period_end_on": "2015-12-31",
+      "period_start_on": "2015-01-01"
+    },
+    "next_due": "2016-06-30",
+    "next_made_up_to": "2015-12-31",
+    "overdue": true
+  },
+  "company_name": "COMPANY NAME",
+  "company_number": "12345678",
+  "company_status": "active",
+  "confirmation_statement": {
+    "last_made_up_to": "2016-06-06"
+  },
+  "date_of_cessation": "2019-01-01",
+  "date_of_creation": "1940-01-22",
+  "etag": "etag",
+  "external_registration_number": "12345",
+  "is_community_interest_company": true,
+  "jurisdiction": "england-wales",
+  "last_full_members_list_date": "2014-05-23",
+  "links": {
+    "filing_history": "/company/12345678/filing-history",
+    "officers": "/company/12345678/officers",
+    "self": "/company/12345678"
+  },
+  "registered_office_address": {
+    "address_line_1": "1 address Road",
+    "address_line_2": "line2",
+    "care_of": "careOf",
+    "country": "Wales",
+    "locality": "Cardiff",
+    "po_box": "12345",
+    "postal_code": "CF01 3AB",
+    "region": "region"
+  },
+  "service_address": {
+    "address_line_1": "1 other Road",
+    "address_line_2": "secondLine",
+    "care_of": "name",
+    "country": "Wales",
+    "locality": "Swansea",
+    "po_box": "21212",
+    "postal_code": "CF15 3UB",
+    "region": "region"
+  },
+  "sic_codes": [
+    "70100"
+  ],
+  "subtype": "private-fund-limited-partnership",
+  "super_secure_managing_officer_count": 0,
+  "type": "private-unlimited"
+}


### PR DESCRIPTION
This PR fixes a deserialisation error that occurs when a message is put on the `stream-company-profile` topic that contains the `super_secure_managing_officer_count` field. Previously, the consumer wasn't expecting this field because it was using an outdated version of `private-api-sdk-java`. 

I have now upgraded the version of the sdk to the most recent version to bring in the most up to date generated spec.

* Upgrade private-api-sdk-version to most recent. Older version did not have required field in spec. The required field is super_secure_managing_officer_count.
* Change unit test to use data json that includes this required field to be sure the changes work.

[DSND-2049](https://companieshouse.atlassian.net/browse/DSND-2049)

[DSND-2049]: https://companieshouse.atlassian.net/browse/DSND-2049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ