### PR TITLE
DSND-2878: Fix failing test

### DIFF
--- a/src/test/java/uk/gov/companieshouse/appointments/subdelta/kafka/ConsumerInvalidTopicTest.java
+++ b/src/test/java/uk/gov/companieshouse/appointments/subdelta/kafka/ConsumerInvalidTopicTest.java
@@ -24,13 +24,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
 @SpringBootTest
 @WireMockTest(httpPort = 8888)
-@ActiveProfiles("test_main_nonretryable")
 class ConsumerInvalidTopicTest extends AbstractKafkaTest {
 
     @Autowired

--- a/src/test/java/uk/gov/companieshouse/appointments/subdelta/kafka/ConsumerNonRetryableExceptionTest.java
+++ b/src/test/java/uk/gov/companieshouse/appointments/subdelta/kafka/ConsumerNonRetryableExceptionTest.java
@@ -29,7 +29,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import uk.gov.companieshouse.appointments.subdelta.companyprofile.ServiceRouter;
@@ -39,7 +38,6 @@ import uk.gov.companieshouse.stream.ResourceChangedData;
 
 @SpringBootTest
 @WireMockTest(httpPort = 8888)
-@ActiveProfiles("test_main_nonretryable")
 class ConsumerNonRetryableExceptionTest extends AbstractKafkaTest {
 
     @Autowired

--- a/src/test/java/uk/gov/companieshouse/appointments/subdelta/kafka/ConsumerRetryableExceptionTest.java
+++ b/src/test/java/uk/gov/companieshouse/appointments/subdelta/kafka/ConsumerRetryableExceptionTest.java
@@ -13,6 +13,7 @@ import static uk.gov.companieshouse.appointments.subdelta.kafka.TestUtils.STREAM
 
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import java.io.ByteArrayOutputStream;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import org.apache.avro.io.DatumWriter;
@@ -23,6 +24,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -55,6 +57,12 @@ class ConsumerRetryableExceptionTest extends AbstractKafkaTest {
     static void props(DynamicPropertyRegistry registry) {
         registry.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
         registry.add("steps", () -> 5);
+    }
+
+    @BeforeEach
+    public void setup() {
+        testConsumerAspect.resetLatch();
+        testConsumer.poll(Duration.ofMillis(1000));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/appointments/subdelta/kafka/ConsumerRetryableExceptionTest.java
+++ b/src/test/java/uk/gov/companieshouse/appointments/subdelta/kafka/ConsumerRetryableExceptionTest.java
@@ -30,7 +30,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import uk.gov.companieshouse.appointments.subdelta.companyprofile.ServiceRouter;
@@ -40,7 +39,6 @@ import uk.gov.companieshouse.stream.ResourceChangedData;
 
 @SpringBootTest
 @WireMockTest(httpPort = 8888)
-@ActiveProfiles("test_main_retryable")
 class ConsumerRetryableExceptionTest extends AbstractKafkaTest {
 
     @Autowired


### PR DESCRIPTION
* test was missing the BeforeEach step where we reset the latch and poll the testConsumer.

## Describe the changes

### Related Jira tickets
[DSND-2878](https://companieshouse.atlassian.net/browse/DSND-2878)

## Developer check list
### General
- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing
- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation
_Where possible, add links to the respective Jira tickets when an item is checked_
- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to `chs-configs`?

## Notes to the tester
_Add any testing hints or instructions here._


[DSND-2878]: https://companieshouse.atlassian.net/browse/DSND-2878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ